### PR TITLE
Add Labelbox to List of Annotation Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,7 @@
 
 ## Annotation Tools:
 
+  + https://github.com/labelbox/labelbox
   + https://github.com/AKSHAYUBHAT/ImageSegmentation
   + https://github.com/kyamagu/js-segment-annotator
   + https://github.com/CSAILVision/LabelMeAnnotationTool


### PR DESCRIPTION
Labelbox is an open source tool I've been working on that makes image segmentation easy todo. We should add it to this list.

![68747470733a2f2f73332d75732d776573742d322e616d617a6f6e6177732e636f6d2f6c6162656c626f782f646f63756d656e746174696f6e2e6173736574732f676966732f45646974696e672b54656d706c6174652e676966](https://user-images.githubusercontent.com/4013767/38774206-1cc2c078-4018-11e8-8414-c3c6d672ff57.gif)
